### PR TITLE
Fix static links and serve assets in debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # CHANGELOG.md
 
-Offline Feedback Collector  
+Offline Feedback Collector
 This document logs all meaningful code changes, grouped by semantic version and date.
 
 ---
+
+## [v0.3.1] 2025-07-31
+
+### Fixed
+- Pointed templates to compiled CSS instead of SCSS
+- Added static file serving in development via `core.urls`
 
 ## [v0.3.0] 2025-07-30
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 from django.shortcuts import render
 from core.views import landing_view
 
@@ -8,3 +10,6 @@ urlpatterns = [
     path("", landing_view, name="landing"),
     path("", include("users.urls")),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/templates/base-other-page.html
+++ b/templates/base-other-page.html
@@ -36,10 +36,10 @@
     <!-- Bootstrap css-->
     <link rel="stylesheet" type="text/css" href="{% static 'assets/css/vendors/bootstrap.css' %}">
     <!-- App css-->
-    <link rel="stylesheet" type="text/css" href="{% static 'assets/scss/style.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/style.css' %}">
     <link id="color" rel="stylesheet" href="{% static 'assets/css/color-1.css' %}" media="screen">
     <!-- Responsive css-->
-    <link rel="stylesheet" type="text/css" href="{% static 'assets/scss/responsive.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/responsive.css' %}">
   </head>
   <body>
 

--- a/templates/pages/others/authentication/sign-up-wizard/sign-up-wizard.html
+++ b/templates/pages/others/authentication/sign-up-wizard/sign-up-wizard.html
@@ -1,5 +1,5 @@
 {% load static %}
-{% load sass_tags %}
+
 
 
 <!DOCTYPE html>
@@ -34,10 +34,10 @@
     <!-- Bootstrap css-->
     <link rel="stylesheet" type="text/css" href="{% static 'assets/css/vendors/bootstrap.css' %}">
     <!-- App css-->
-    <link rel="stylesheet" type="text/css" href="{% sass_src 'assets/scss/style.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/style.css' %}">
     <link id="color" rel="stylesheet" href="{% static 'assets/css/color-1.css' %}" media="screen">
     <!-- Responsive css-->
-    <link rel="stylesheet" type="text/css" href="{% sass_src 'assets/scss/responsive.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/responsive.css' %}">
   </head>
   <body>
 

--- a/templates/pages/others/comingsoon/comingsoon-img/comingsoon-bg-img.html
+++ b/templates/pages/others/comingsoon/comingsoon-img/comingsoon-bg-img.html
@@ -32,10 +32,10 @@
     <!-- Bootstrap css-->
     <link rel="stylesheet" type="text/css" href="{% static 'assets/css/vendors/bootstrap.css' %}">
     <!-- App css-->
-    <link rel="stylesheet" type="text/css" href="{% sass_src 'assets/scss/style.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/style.css' %}">
     <link id="color" rel="stylesheet" href="{% static 'assets/css/color-1.css' %}" media="screen">
     <!-- Responsive css-->
-    <link rel="stylesheet" type="text/css" href="{% sass_src 'assets/scss/responsive.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/responsive.css' %}">
   </head>
   <body>
     <!-- tap on top starts-->

--- a/templates/pages/others/comingsoon/comingsoon-video/comingsoon-bg-video.html
+++ b/templates/pages/others/comingsoon/comingsoon-video/comingsoon-bg-video.html
@@ -33,10 +33,10 @@
     <!-- Bootstrap css-->
     <link rel="stylesheet" type="text/css" href="{% static 'assets/css/vendors/bootstrap.css' %}">
     <!-- App css-->
-    <link rel="stylesheet" type="text/css" href="{% sass_src 'assets/scss/style.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/style.css' %}">
     <link id="color" rel="stylesheet" href="{% static 'assets/css/color-1.css' %}" media="screen">
     <!-- Responsive css-->
-    <link rel="stylesheet" type="text/css" href="{% sass_src 'assets/scss/responsive.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/responsive.css' %}">
   </head>
   <body>
     <!-- tap on top starts-->

--- a/templates/pages/others/comingsoon/comingsoon/comingsoon.html
+++ b/templates/pages/others/comingsoon/comingsoon/comingsoon.html
@@ -32,10 +32,10 @@
     <!-- Bootstrap css-->
     <link rel="stylesheet" type="text/css" href="{% static 'assets/css/vendors/bootstrap.css' %}">
     <!-- App css-->
-    <link rel="stylesheet" type="text/css" href="{% sass_src 'assets/scss/style.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/style.css' %}">
     <link id="color" rel="stylesheet" href="{% static 'assets/css/color-1.css' %}" media="screen">
     <!-- Responsive css-->
-    <link rel="stylesheet" type="text/css" href="{% sass_src 'assets/scss/responsive.scss' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'assets/css/responsive.css' %}">
   </head>
   <body>
     <!-- tap on top starts-->

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "name": "offline-feedback",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "environment": "local",
-  "release_date": "2025-07-30",
-  "release_notes": "/registration /login created"
+  "release_date": "2025-07-31",
+  "release_notes": "Static path fixes and dev static serving"
 }


### PR DESCRIPTION
## Summary
- serve static assets in `core.urls` when DEBUG is true
- link compiled CSS instead of SCSS in base templates
- fix sign-up/comingsoon pages to reference compiled CSS
- bump version.json

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_b_688add21ed188332946045ceb9e44325