### PR TITLE
Fix sidebar layout structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This document logs all meaningful code changes, grouped by semantic version and 
 - Pointed templates to compiled CSS instead of SCSS
 - Added static file serving in development via `core.urls`
 
+## [v0.3.2] 2025-07-31
+
+### Fixed
+- Corrected sidebar markup and overlay for responsive layout
+
 ## [v0.3.0] 2025-07-30
 
 ### Added

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,8 +25,10 @@
 
       <!-- Main Body -->
       <div class="page-body-wrapper">
-        {% include 'layout/sidebar.html' %}
-        
+        <div id="sidebarOverlay" class="d-none d-md-block position-fixed position-md-static top-0 start-0 vh-100 bg-white overflow-auto">
+          {% include 'layout/sidebar.html' %}
+        </div>
+
         <main class="page-body">
           {% block content %}{% endblock %}
         </main>

--- a/templates/layout/sidebar.html
+++ b/templates/layout/sidebar.html
@@ -42,3 +42,9 @@
               <i data-feather="message-circle"></i><span>Feedback (coming soon)</span>
             </a>
           </li>
+
+        </ul>
+      </div>
+    </nav>
+  </div>
+</div>

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "name": "offline-feedback",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "environment": "local",
   "release_date": "2025-07-31",
-  "release_notes": "Static path fixes and dev static serving"
+  "release_notes": "Fixed sidebar layout structure"
 }


### PR DESCRIPTION
## Summary
- restore closing tags for sidebar navigation
- wrap sidebar in overlay container
- bump patch version
- note fix in CHANGELOG

## Testing
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_b_688ae2ed8e0c83329e4ad04a5cbe23af